### PR TITLE
Fixed truffleAssert.fails not asserting if the method didn't fail at all.

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,6 @@ const createTransactionResult = async (contract, transactionHash) => {
 const fails = async (asyncFn, errorType, reason, message) => {
   try {
     await asyncFn;
-    
   } catch (error) {
     if (errorType && !error.message.includes(errorType)) {
       const assertionMessage = createAssertionMessage(message, `Expected to fail with ${errorType}, but failed with: ${error}`);
@@ -127,11 +126,9 @@ const fails = async (asyncFn, errorType, reason, message) => {
       const assertionMessage = createAssertionMessage(message, `Expected to fail with ${reason}, but failed with: ${error}`);
       throw new AssertionError(assertionMessage);
     }
-
     // Eror was handled by errorType or reason
     return;
   }
-
   const assertionMessage = createAssertionMessage(message, 'Did not fail');
   throw new AssertionError(assertionMessage);
 };

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ const fails = async (asyncFn, errorType, reason, message) => {
       const assertionMessage = createAssertionMessage(message, `Expected to fail with ${reason}, but failed with: ${error}`);
       throw new AssertionError(assertionMessage);
     }
-    // Eror was handled by errorType or reason
+    // Error was handled by errorType or reason
     return;
   }
   const assertionMessage = createAssertionMessage(message, 'Did not fail');

--- a/index.js
+++ b/index.js
@@ -118,8 +118,7 @@ const createTransactionResult = async (contract, transactionHash) => {
 const fails = async (asyncFn, errorType, reason, message) => {
   try {
     await asyncFn;
-    const assertionMessage = createAssertionMessage(message, 'Did not fail');
-    throw new AssertionError(assertionMessage);
+    
   } catch (error) {
     if (errorType && !error.message.includes(errorType)) {
       const assertionMessage = createAssertionMessage(message, `Expected to fail with ${errorType}, but failed with: ${error}`);
@@ -128,7 +127,13 @@ const fails = async (asyncFn, errorType, reason, message) => {
       const assertionMessage = createAssertionMessage(message, `Expected to fail with ${reason}, but failed with: ${error}`);
       throw new AssertionError(assertionMessage);
     }
+
+    // Eror was handled by errorType or reason
+    return;
   }
+
+  const assertionMessage = createAssertionMessage(message, 'Did not fail');
+  throw new AssertionError(assertionMessage);
 };
 
 const ErrorType = {


### PR DESCRIPTION
Delayed the throwing of the AssertionError until after the try/catch block for the fails function to properly handle when asyncFn does not fail.

Added a return statement at the end of the catch block to prevent the AssertionError from throwing even if asyncFn did fail correctly.

Bug detailed in: https://github.com/rkalis/truffle-assertions/issues/7