### PR TITLE
add passes assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,31 @@ truffleAssert.eventEmitted(result, 'TestEvent');
 
 ---
 
+### truffleAssert.passes(asyncFn\[, message])
+Asserts that the passed async contract function does not fail.
+
+```javascript
+await truffleAssert.passes(
+    contractInstance.methodThatShouldPass()
+);
+```
+
+Optionally, a custom message can be passed to the assertion, which will be displayed alongside the default one:
+
+```javascript
+await truffleAssert.passes(
+    contractInstance.methodThatShouldPass(),
+    'This method should not run out of gas'
+);
+```
+
+The default message is
+```javascript
+`Failed with ${error}`
+```
+
+---
+
 ### truffleAssert.fails(asyncFn\[, errorType]\[, reason]\[, message])
 Asserts that the passed async contract function fails with a certain ErrorType and reason.
 

--- a/index.js
+++ b/index.js
@@ -120,6 +120,15 @@ createTransactionResult = async (contract, transactionHash) => {
   }
 }
 
+passes = async (asyncFn, message) => {
+  try {
+    await asyncFn;
+  } catch (error) {
+    const assertionMessage = createAssertionMessage(message, `Failed with ${error}`);
+    throw new AssertionError(assertionMessage);
+  }
+}
+
 fails = async (asyncFn, errorType, reason, message) => {
   try {
     await asyncFn;
@@ -155,6 +164,9 @@ module.exports = {
   },
   createTransactionResult: (contract, transactionHash) => {
     return createTransactionResult(contract, transactionHash);
+  },
+  passes: async (asyncFn, message) => {
+    return passes(asyncFn, message);
   },
   fails: async (asyncFn, errorType, reason, message) => {
     return fails(asyncFn, errorType, reason, message);


### PR DESCRIPTION
This might be a bit tautological, but I think having a `passes` assertion is useful when, for example, one wants to be very clear about which combinations of parameters are allowed to be passed to a particular function, in addition to which are not.