### PR TITLE
encapsulate await keyword within exported functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ There can be times where we only have access to a transaction hash, and not to a
 
 ```javascript
 let contractInstance = await Contract.new();
-let result = await truffleAssert.createTransactionResult(contractInstance, contractInstance.transactionHash);
+let result = truffleAssert.createTransactionResult(contractInstance, contractInstance.transactionHash);
 
 truffleAssert.eventEmitted(result, 'TestEvent');
 ```
@@ -130,7 +130,7 @@ ErrorType = {
 ```
 
 ```javascript
-await truffleAssert.fails(
+truffleAssert.fails(
     contractInstance.methodThatShouldFail(),
     truffleAssert.ErrorType.OUT_OF_GAS
 );
@@ -139,7 +139,7 @@ await truffleAssert.fails(
 A reason can be passed to the assertion, which functions as an extra filter on the revert reason (note that this is only relevant in the case of revert, not for the other ErrorTypes). This functionality requires at least Truffle v0.5.
 
 ```javascript
-await truffleAssert.fails(
+truffleAssert.fails(
     contractInstance.methodThatShouldFail(),
     truffleAssert.ErrorType.REVERT,
     "only owner"
@@ -149,13 +149,13 @@ await truffleAssert.fails(
 If the errorType parameter is omitted or set to null, the function just checks for failure, regardless of cause.
 
 ```javascript
-await truffleAssert.fails(contractInstance.methodThatShouldFail());
+truffleAssert.fails(contractInstance.methodThatShouldFail());
 ```
 
 Optionally, a custom message can be passed to the assertion, which will be displayed alongside the default one:
 
 ```javascript
-await truffleAssert.fails(
+truffleAssert.fails(
     contractInstance.methodThatShouldFail(),
     truffleAssert.ErrorType.OUT_OF_GAS,
     null,
@@ -175,7 +175,7 @@ The default messages are
 This is an alias for `truffleAssert.fails(asyncFn, truffleAssert.ErrorType.REVERT[, reason][, message])`.
 
 ```javascript
-await truffleAssert.reverts(
+truffleAssert.reverts(
     contractInstance.methodThatShouldRevert(),
     "only owner"
 );

--- a/index.js
+++ b/index.js
@@ -153,14 +153,14 @@ module.exports = {
   prettyPrintEmittedEvents: (result) => {
     console.log(getPrettyEmittedEventsString(result));
   },
-  createTransactionResult: (contract, transactionHash) => {
-    return createTransactionResult(contract, transactionHash);
+  createTransactionResult: async (contract, transactionHash) => {
+    return await createTransactionResult(contract, transactionHash);
   },
   fails: async (asyncFn, errorType, reason, message) => {
-    return fails(asyncFn, errorType, reason, message);
+    return await fails(asyncFn, errorType, reason, message);
   },
   reverts: async (asyncFn, reason, message) => {
-    return fails(asyncFn, ErrorType.REVERT, reason, message);
+    return await fails(asyncFn, ErrorType.REVERT, reason, message);
   },
   ErrorType: ErrorType
 }


### PR DESCRIPTION
I was encountering non-deterministic behavior as a result of having forgotten the `await` keyword before calling some of the assertions.  I think if the keyword were moved to the exported functions, this mistake could be avoided, and the `truffle-assertions` syntax would match that of the regular assertions.

I don't have much experience with `async/await`, but this seems to work in my tests.  Do you know of a case in which this would break?