### PR TITLE
print expected failure reason when provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ fails = async (asyncFn, errorType, reason, message) => {
   } catch (error) {
     if (errorType && !error.message.includes(errorType) ||
         reason && !error.message.includes(reason)) {
-      const assertionMessage = createAssertionMessage(message, `Expected to fail with ${errorType}, but failed with: ${error}`);
+      const assertionMessage = createAssertionMessage(message, `Expected to fail with ${[errorType, reason].join(' ').trim()}, but failed with: ${error}`);
       throw new AssertionError(assertionMessage);
     }
     // Error was handled by errorType or reason


### PR DESCRIPTION
When a transaction is expected to fail with a given reason, but instead fails for a different reason, the given reason should be included in the error message.

The current behavior can be confusing.  For example:
`AssertionError: [message] : Expected to fail with revert, but failed with: Error: Returned error: VM Exception while processing transaction: revert`